### PR TITLE
fix: commandsの実行エラーがトーストにしか表示されない問題を修正

### DIFF
--- a/src-tauri/src/command/asset/adapter.rs
+++ b/src-tauri/src/command/asset/adapter.rs
@@ -16,6 +16,7 @@ pub async fn import_from_other_data_store(
     let current_data_dir = basic_store.lock().await.data_dir();
 
     if path.starts_with(&current_data_dir) {
+        log::error!("Cannot import assets from the same data store: {}", path.display());
         return Err(format!(
             "Cannot import assets from the same data store: {}",
             path.display()
@@ -71,6 +72,7 @@ pub async fn export_as_konoasset_zip(
     let current_data_dir = basic_store.lock().await.data_dir();
 
     if path.starts_with(&current_data_dir) {
+        log::error!("Export path cannot be inside the data store: {}", path.display());
         return Err(format!(
             "Export path cannot be inside the data store: {}",
             path.display()
@@ -115,6 +117,7 @@ pub async fn export_for_avatar_explorer(
     let current_data_dir = basic_store.lock().await.data_dir();
 
     if path.starts_with(&current_data_dir) {
+        log::error!("Export path cannot be inside the data store: {}", path.display());
         return Err(format!(
             "Export path cannot be inside the data store: {}",
             path.display()
@@ -162,6 +165,7 @@ pub async fn export_as_human_readable_zip(
     let current_data_dir = basic_store.lock().await.data_dir();
 
     if path.starts_with(&current_data_dir) {
+        log::error!("Export path cannot be inside the data store: {}", path.display());
         return Err(format!(
             "Export path cannot be inside the data store: {}",
             path.display()

--- a/src-tauri/src/command/asset/adapter.rs
+++ b/src-tauri/src/command/asset/adapter.rs
@@ -16,11 +16,9 @@ pub async fn import_from_other_data_store(
     let current_data_dir = basic_store.lock().await.data_dir();
 
     if path.starts_with(&current_data_dir) {
-        log::error!("Cannot import assets from the same data store: {}", path.display());
-        return Err(format!(
-            "Cannot import assets from the same data store: {}",
-            path.display()
-        ));
+        let err = format!("Cannot import assets from the same data store: {}", path.display());
+        log::error!("{}", err);
+        return Err(err);
     }
 
     log::info!("Importing assets from external path: {}", path.display());
@@ -72,11 +70,9 @@ pub async fn export_as_konoasset_zip(
     let current_data_dir = basic_store.lock().await.data_dir();
 
     if path.starts_with(&current_data_dir) {
-        log::error!("Export path cannot be inside the data store: {}", path.display());
-        return Err(format!(
-            "Export path cannot be inside the data store: {}",
-            path.display()
-        ));
+        let err = format!("Export path cannot be inside the data store: {}", path.display());
+        log::error!("{}", err);
+        return Err(err);
     }
 
     log::info!("Exporting assets as KonoAsset zip to: {}", path.display());
@@ -117,11 +113,9 @@ pub async fn export_for_avatar_explorer(
     let current_data_dir = basic_store.lock().await.data_dir();
 
     if path.starts_with(&current_data_dir) {
-        log::error!("Export path cannot be inside the data store: {}", path.display());
-        return Err(format!(
-            "Export path cannot be inside the data store: {}",
-            path.display()
-        ));
+        let err = format!("Export path cannot be inside the data store: {}", path.display());
+        log::error!("{}", err);
+        return Err(err);
     }
 
     log::info!(
@@ -165,11 +159,9 @@ pub async fn export_as_human_readable_zip(
     let current_data_dir = basic_store.lock().await.data_dir();
 
     if path.starts_with(&current_data_dir) {
-        log::error!("Export path cannot be inside the data store: {}", path.display());
-        return Err(format!(
-            "Export path cannot be inside the data store: {}",
-            path.display()
-        ));
+        let err = format!("Export path cannot be inside the data store: {}", path.display());
+        log::error!("{}", err);
+        return Err(err);
     }
 
     log::info!(

--- a/src-tauri/src/command/asset/get.rs
+++ b/src-tauri/src/command/asset/get.rs
@@ -34,8 +34,9 @@ pub async fn get_asset(
         return Ok(GetAssetResult::world_object(asset));
     }
 
-    log::error!("Asset not found: {:?}", id);
-    Err("Asset not found".into())
+    let err = format!("Asset not found: {:?}", id);
+    log::error!("{}", err);
+    Err(err)
 }
 
 #[tauri::command]

--- a/src-tauri/src/command/asset/get.rs
+++ b/src-tauri/src/command/asset/get.rs
@@ -34,6 +34,7 @@ pub async fn get_asset(
         return Ok(GetAssetResult::world_object(asset));
     }
 
+    log::error!("Asset not found: {:?}", id);
     Err("Asset not found".into())
 }
 

--- a/src-tauri/src/command/external/booth.rs
+++ b/src-tauri/src/command/external/booth.rs
@@ -44,5 +44,8 @@ pub async fn resolve_pximg_filename(
         resolver.resolve(&url).await
     };
 
-    result.map_err(|e| e.to_string())
+    result.map_err(|e| {
+        log::error!("Failed to resolve pximg filename: {}", e);
+        e.to_string()
+    })
 }

--- a/src-tauri/src/command/file/common.rs
+++ b/src-tauri/src/command/file/common.rs
@@ -26,7 +26,10 @@ pub async fn get_directory_path(
 
     match app_dir.to_str() {
         Some(ans) => Ok(ans.to_string()),
-        None => return Err(format!("Failed to convert path to string (id = {:?})", id)),
+        None => {
+            log::error!("Failed to convert path to string (id = {:?})", id);
+            return Err(format!("Failed to convert path to string (id = {:?})", id))
+        },
     }
 }
 
@@ -41,6 +44,7 @@ pub async fn list_unitypackage_files(
     dir.push(id.to_string());
 
     if !dir.exists() {
+        log::error!("Directory does not exist: {}", dir.display());
         return Err("Directory does not exist".into());
     }
 

--- a/src-tauri/src/command/file/common.rs
+++ b/src-tauri/src/command/file/common.rs
@@ -27,8 +27,9 @@ pub async fn get_directory_path(
     match app_dir.to_str() {
         Some(ans) => Ok(ans.to_string()),
         None => {
-            log::error!("Failed to convert path to string (id = {:?})", id);
-            return Err(format!("Failed to convert path to string (id = {:?})", id))
+            let err = format!("Failed to convert path to string (id = {:?})", id);
+            log::error!("{}", err);
+            return Err(err);
         },
     }
 }
@@ -44,8 +45,9 @@ pub async fn list_unitypackage_files(
     dir.push(id.to_string());
 
     if !dir.exists() {
-        log::error!("Directory does not exist: {}", dir.display());
-        return Err("Directory does not exist".into());
+        let err = format!("Directory does not exist: {}", dir.display());
+        log::error!("{}", err);
+        return Err(err);
     }
 
     Ok(find_unitypackage(&dir)?)

--- a/src-tauri/src/command/file/delete.rs
+++ b/src-tauri/src/command/file/delete.rs
@@ -23,18 +23,26 @@ pub async fn delete_entry_from_asset_data_dir(
     };
 
     if !path.exists() {
+        log::error!("File or directory does not exist: {:?}", path);
         return Err(format!("File or directory does not exist: {:?}", path));
     }
 
     if path.is_file() {
         tokio::fs::remove_file(&path)
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| {
+                log::error!("Failed to delete file: {:?}", e);
+                e.to_string()
+            })?;
     } else if path.is_dir() {
         tokio::fs::remove_dir_all(&path)
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| {
+                log::error!("Failed to delete directory: {:?}", e);
+                e.to_string()
+            })?;
     } else {
+        log::error!("Path is not a file or directory: {:?}", path);
         return Err(format!("Path is not a file or directory: {:?}", path));
     }
 

--- a/src-tauri/src/command/file/delete.rs
+++ b/src-tauri/src/command/file/delete.rs
@@ -23,27 +23,31 @@ pub async fn delete_entry_from_asset_data_dir(
     };
 
     if !path.exists() {
-        log::error!("File or directory does not exist: {:?}", path);
-        return Err(format!("File or directory does not exist: {:?}", path));
+        let err = format!("File or directory does not exist: {:?}", path);
+        log::error!("{}", err);
+        return Err(err);
     }
 
     if path.is_file() {
         tokio::fs::remove_file(&path)
             .await
             .map_err(|e| {
-                log::error!("Failed to delete file: {:?}", e);
-                e.to_string()
+                let err = format!("Failed to delete file: {:?}", e);
+                log::error!("{}", err);
+                err
             })?;
     } else if path.is_dir() {
         tokio::fs::remove_dir_all(&path)
             .await
             .map_err(|e| {
-                log::error!("Failed to delete directory: {:?}", e);
-                e.to_string()
+                let err = format!("Failed to delete directory: {:?}", e);
+                log::error!("{}", err);
+                err
             })?;
     } else {
-        log::error!("Path is not a file or directory: {:?}", path);
-        return Err(format!("Path is not a file or directory: {:?}", path));
+        let err = format!("Path is not a file or directory: {:?}", path);
+        log::error!("{}", err);
+        return Err(err);
     }
 
     Ok(())

--- a/src-tauri/src/command/file/list.rs
+++ b/src-tauri/src/command/file/list.rs
@@ -21,7 +21,8 @@ pub async fn list_asset_dir_entry(
     let result = list_top_files_and_directories(&dir).await;
 
     result.map_err(|e| {
-        log::error!("Failed to list directory: {:?}", e);
-        e.to_string()
+        let err = format!("Failed to list directory: {:?}", e);
+        log::error!("{}", err);
+        err
     })
 }

--- a/src-tauri/src/command/file/list.rs
+++ b/src-tauri/src/command/file/list.rs
@@ -20,5 +20,8 @@ pub async fn list_asset_dir_entry(
 
     let result = list_top_files_and_directories(&dir).await;
 
-    result.map_err(|e| e.to_string())
+    result.map_err(|e| {
+        log::error!("Failed to list directory: {:?}", e);
+        e.to_string()
+    })
 }

--- a/src-tauri/src/command/preference/common.rs
+++ b/src-tauri/src/command/preference/common.rs
@@ -36,13 +36,15 @@ pub async fn set_preferences(
     let mut preference = preference.lock().await;
 
     if preference.get_data_dir() != new_preference.get_data_dir() {
-        log::error!("Data directory cannot be changed via set_preferences function");
-        return Err("Data directory cannot be changed via set_preferences function".into());
+        let err = "Data directory cannot be changed via set_preferences function".to_string();
+        log::error!("{}", err);
+        return Err(err);
     }
 
     preference.overwrite(&new_preference);
     preference.save().map_err(|e| {
-        log::error!("Failed to save preferences: {}", e);
-        e.to_string()
+        let err = format!("Failed to save preferences: {}", e);
+        log::error!("{}", err);
+        err
     })
 }

--- a/src-tauri/src/command/preference/common.rs
+++ b/src-tauri/src/command/preference/common.rs
@@ -36,9 +36,13 @@ pub async fn set_preferences(
     let mut preference = preference.lock().await;
 
     if preference.get_data_dir() != new_preference.get_data_dir() {
+        log::error!("Data directory cannot be changed via set_preferences function");
         return Err("Data directory cannot be changed via set_preferences function".into());
     }
 
     preference.overwrite(&new_preference);
-    preference.save().map_err(|e| e.to_string())
+    preference.save().map_err(|e| {
+        log::error!("Failed to save preferences: {}", e);
+        e.to_string()
+    })
 }

--- a/src-tauri/src/command/preference/reset.rs
+++ b/src-tauri/src/command/preference/reset.rs
@@ -21,8 +21,9 @@ pub async fn reset_application(
             .path()
             .app_local_data_dir()
             .map_err(|e| {
-                log::error!("Unable to get app dir: {}", e);
-                format!("Unable to get app dir: {}", e)
+                let err = format!("Unable to get app dir: {}", e);
+                log::error!("{}", err);
+                err
             })?;
         let preference_path = app_local_data_dir.join("preference.json");
 

--- a/src-tauri/src/command/preference/reset.rs
+++ b/src-tauri/src/command/preference/reset.rs
@@ -20,7 +20,10 @@ pub async fn reset_application(
         let app_local_data_dir = handle
             .path()
             .app_local_data_dir()
-            .map_err(|e| format!("Unable to get app dir: {}", e))?;
+            .map_err(|e| {
+                log::error!("Unable to get app dir: {}", e);
+                format!("Unable to get app dir: {}", e)
+            })?;
         let preference_path = app_local_data_dir.join("preference.json");
 
         if preference_path.exists() {

--- a/src-tauri/src/command/task/status.rs
+++ b/src-tauri/src/command/task/status.rs
@@ -21,8 +21,9 @@ pub async fn get_task_status(
             Ok(status)
         }
         None => {
-            log::error!("Task not found: {:?}", id);
-            Err("Task not found.".into())
+            let err = format!("Task not found: {:?}", id);
+            log::error!("{}", err);
+            Err(err)
         },
     }
 }
@@ -43,8 +44,9 @@ pub async fn cancel_task_request(
             Ok(status)
         }
         None => {
-            log::error!("Task not found: {:?}", id);
-            Err("Task not found.".into())
+            let err = format!("Task not found: {:?}", id);
+            log::error!("{}", err);
+            Err(err)
         },
     }
 }
@@ -65,8 +67,9 @@ pub async fn get_task_error(
             Ok(error)
         }
         None => {
-            log::error!("Task not found: {:?}", id);
-            Err("Task not found.".into())
+            let err = format!("Task not found: {:?}", id);
+            log::error!("{}", err);
+            Err(err)
         },
     }
 }

--- a/src-tauri/src/command/task/status.rs
+++ b/src-tauri/src/command/task/status.rs
@@ -20,7 +20,10 @@ pub async fn get_task_status(
             let status = task.get_status().await;
             Ok(status)
         }
-        None => Err("Task not found.".into()),
+        None => {
+            log::error!("Task not found: {:?}", id);
+            Err("Task not found.".into())
+        },
     }
 }
 
@@ -39,7 +42,10 @@ pub async fn cancel_task_request(
             let status = task.abort().await?;
             Ok(status)
         }
-        None => Err("Task not found.".into()),
+        None => {
+            log::error!("Task not found: {:?}", id);
+            Err("Task not found.".into())
+        },
     }
 }
 
@@ -58,6 +64,9 @@ pub async fn get_task_error(
             let error = task.get_error().await;
             Ok(error)
         }
-        None => Err("Task not found.".into()),
+        None => {
+            log::error!("Task not found: {:?}", id);
+            Err("Task not found.".into())
+        },
     }
 }

--- a/src-tauri/src/command/update/common.rs
+++ b/src-tauri/src/command/update/common.rs
@@ -13,8 +13,9 @@ pub async fn check_for_update(
     let handler = update_handler.lock().await;
 
     if !handler.is_initialized() {
-        log::error!("Update handler is not initialized yet.");
-        return Err(format!("Update handler is not initialized yet."));
+        let err = "Update handler is not initialized yet.".to_string();
+        log::error!("{}", err);
+        return Err(err);
     }
 
     if !handler.show_notification().await {

--- a/src-tauri/src/command/update/common.rs
+++ b/src-tauri/src/command/update/common.rs
@@ -13,6 +13,7 @@ pub async fn check_for_update(
     let handler = update_handler.lock().await;
 
     if !handler.is_initialized() {
+        log::error!("Update handler is not initialized yet.");
         return Err(format!("Update handler is not initialized yet."));
     }
 
@@ -32,10 +33,12 @@ pub async fn execute_update(
     let handler = update_handler.lock().await;
 
     if !handler.is_initialized() {
+        log::error!("Update handler is not initialized yet.");
         return Err("Update handler is not initialized yet.".into());
     }
 
     if !handler.update_available() {
+        log::error!("No update available.");
         return Err("No update available.".into());
     }
 
@@ -44,7 +47,10 @@ pub async fn execute_update(
 
     match result {
         Ok(_) => Ok(true),
-        Err(e) => Err(e.to_string()),
+        Err(e) => {
+            log::error!("Failed to execute update: {:?}", e);
+            Err(e.to_string())
+        },
     }
 }
 
@@ -56,6 +62,7 @@ pub async fn do_not_notify_update(
     let mut handler = update_handler.lock().await;
 
     if !handler.is_initialized() {
+        log::error!("Update handler is not initialized yet.");
         return Err("Update handler is not initialized yet.".into());
     }
 

--- a/src-tauri/src/command/update/common.rs
+++ b/src-tauri/src/command/update/common.rs
@@ -33,13 +33,15 @@ pub async fn execute_update(
     let handler = update_handler.lock().await;
 
     if !handler.is_initialized() {
-        log::error!("Update handler is not initialized yet.");
-        return Err("Update handler is not initialized yet.".into());
+        let err = "Update handler is not initialized yet.".to_string();
+        log::error!("{}", err);
+        return Err(err);
     }
 
     if !handler.update_available() {
-        log::error!("No update available.");
-        return Err("No update available.".into());
+        let err = "No update available.".to_string();
+        log::error!("{}", err);
+        return Err(err);
     }
 
     log::info!("Executing update. This will restart the application.");
@@ -48,8 +50,9 @@ pub async fn execute_update(
     match result {
         Ok(_) => Ok(true),
         Err(e) => {
-            log::error!("Failed to execute update: {:?}", e);
-            Err(e.to_string())
+            let err = format!("Failed to execute update: {:?}", e);
+            log::error!("{}", err);
+            Err(err)
         },
     }
 }
@@ -62,8 +65,9 @@ pub async fn do_not_notify_update(
     let mut handler = update_handler.lock().await;
 
     if !handler.is_initialized() {
-        log::error!("Update handler is not initialized yet.");
-        return Err("Update handler is not initialized yet.".into());
+        let err = "Update handler is not initialized yet.".to_string();
+        log::error!("{}", err);
+        return Err(err);
     }
 
     handler.set_show_notification(false).await;


### PR DESCRIPTION
エラーをログにも出力するように変更されてます。
一部元からあったエラーメッセージに編集が加わっているので、そこのチェックなどお願いします。
必要ない所は削ってください。

エラーメッセージの編集例：
```Rust
e.to_string()
```
を次のように変更したりするなど
```Rust
format!("Failed to 〇〇: {:?}", e)
```

### Issue
- [x] #275 