### PR TITLE
feat: アセット追加ダイアログを開くための Deep Link をサポート

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@tanstack/react-router": "^1.86.1",
     "@tanstack/router-devtools": "^1.86.1",
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-deep-link": "~2",
     "@tauri-apps/plugin-dialog": "~2",
     "@tauri-apps/plugin-shell": "^2",
     "@tauri-apps/plugin-updater": "~2.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.2.0
+      '@tauri-apps/plugin-deep-link':
+        specifier: ~2
+        version: 2.2.0
       '@tauri-apps/plugin-dialog':
         specifier: ~2
         version: 2.2.0
@@ -1362,6 +1365,9 @@ packages:
     resolution: {integrity: sha512-ZnsS2B4BplwXP37celanNANiIy8TCYhvg5RT09n72uR/o+navFZtGpFSqljV8fy1Y4ixIPds8FrGSXJCN2BerA==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-deep-link@2.2.0':
+    resolution: {integrity: sha512-H6mkxr2KZ3XJcKL44tiq6cOjCw9DL8OgU1xjn3j26Qsn+H/roPFiyhR7CHuB8Ar+sQFj4YVlfmJwtBajK2FETQ==}
 
   '@tauri-apps/plugin-dialog@2.2.0':
     resolution: {integrity: sha512-6bLkYK68zyK31418AK5fNccCdVuRnNpbxquCl8IqgFByOgWFivbiIlvb79wpSXi0O+8k8RCSsIpOquebusRVSg==}
@@ -4268,6 +4274,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.2.7
       '@tauri-apps/cli-win32-ia32-msvc': 2.2.7
       '@tauri-apps/cli-win32-x64-msvc': 2.2.7
+
+  '@tauri-apps/plugin-deep-link@2.2.0':
+    dependencies:
+      '@tauri-apps/api': 2.2.0
 
   '@tauri-apps/plugin-dialog@2.2.0':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -679,6 +679,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,6 +796,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -1009,6 +1035,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1691,6 +1726,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -2246,6 +2287,7 @@ dependencies = [
  "specta-typescript",
  "tauri",
  "tauri-build",
+ "tauri-plugin-deep-link",
  "tauri-plugin-dialog",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
@@ -3031,6 +3073,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,7 +3775,7 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
- "windows-registry",
+ "windows-registry 0.2.0",
 ]
 
 [[package]]
@@ -3770,6 +3822,17 @@ name = "ringbuffer"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
+
+[[package]]
+name = "rust-ini"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+ "trim-in-place",
+]
 
 [[package]]
 name = "rustbus"
@@ -4668,6 +4731,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35d51ffd286073414d26353bcfc9e83e3cd63f96fa7f7a912f92f2118e5de5a6"
+dependencies = [
+ "dunce",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.11",
+ "tracing",
+ "url",
+ "windows-registry 0.3.0",
+ "windows-result",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4738,6 +4821,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
+ "tauri-plugin-deep-link",
  "thiserror 2.0.11",
  "tracing",
  "windows-sys 0.59.0",
@@ -4998,6 +5082,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5234,6 +5327,12 @@ dependencies = [
  "thiserror 2.0.11",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
 
 [[package]]
 name = "try-lock"
@@ -5795,7 +5894,7 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-result",
- "windows-strings",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -5834,7 +5933,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
- "windows-strings",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafa604f2104cf5ae2cc2db1dee84b7e6a5d11b05f737b60def0ffdc398cbc0a"
+dependencies = [
+ "windows-result",
+ "windows-strings 0.2.0",
  "windows-targets 0.52.6",
 ]
 
@@ -5854,6 +5964,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978d65aedf914c664c510d9de43c8fd85ca745eaff1ed53edf409b479e441663"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,7 +42,8 @@ specta = {version = "=2.0.0-rc.22", features = ["uuid", "chrono"] }
 specta-typescript = "0.0.9"
 tauri-specta = { version = "=2.0.0-rc.21", features = ["derive", "typescript"] }
 serde_with = "3.12.0"
+tauri-plugin-deep-link = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
-tauri-plugin-single-instance = "2"
+tauri-plugin-single-instance = {version = "2", features = ["deep-link"] }
 tauri-plugin-updater = "2"

--- a/src-tauri/src/command/deep_link/execute.rs
+++ b/src-tauri/src/command/deep_link/execute.rs
@@ -1,0 +1,21 @@
+use std::sync::Arc;
+
+use tauri::{AppHandle, State};
+use tokio::sync::Mutex;
+
+use crate::deep_link::definitions::StartupDeepLinkStore;
+
+#[tauri::command]
+#[specta::specta]
+pub async fn request_startup_deep_link_execution(
+    app_handle: State<'_, AppHandle>,
+    startup_deep_links: State<'_, Arc<Mutex<StartupDeepLinkStore>>>,
+) -> Result<(), String> {
+    let mut store = startup_deep_links.lock().await;
+
+    if let Some(deep_links) = store.get() {
+        crate::deep_link::execute_deep_links(&app_handle, &deep_links);
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/command/deep_link/mod.rs
+++ b/src-tauri/src/command/deep_link/mod.rs
@@ -1,0 +1,1 @@
+pub mod execute;

--- a/src-tauri/src/command/mod.rs
+++ b/src-tauri/src/command/mod.rs
@@ -1,6 +1,7 @@
 use tauri_specta::{collect_commands, Builder};
 
 mod asset;
+mod deep_link;
 mod external;
 mod file;
 mod language;
@@ -71,5 +72,7 @@ pub fn generate_tauri_specta_builder() -> Builder<tauri::Wry> {
         language::common::set_language_code,
         language::common::get_current_language_data,
         language::common::load_language_file,
+        // DeepLink関係
+        deep_link::execute::request_startup_deep_link_execution,
     ])
 }

--- a/src-tauri/src/deep_link/definitions.rs
+++ b/src-tauri/src/deep_link/definitions.rs
@@ -1,0 +1,43 @@
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+pub struct StartupDeepLinkStore {
+    deep_links: Option<Vec<DeepLinkAction>>,
+}
+
+impl StartupDeepLinkStore {
+    pub fn new(deep_links: Vec<DeepLinkAction>) -> Self {
+        if deep_links.is_empty() {
+            return Self { deep_links: None };
+        }
+
+        Self {
+            deep_links: Some(deep_links),
+        }
+    }
+
+    pub fn get(&mut self) -> Option<Vec<DeepLinkAction>> {
+        self.deep_links.take()
+    }
+}
+
+pub enum DeepLinkAction {
+    AddAsset(AddAssetDeepLink),
+}
+
+#[derive(Serialize, Debug, Clone, specta::Type, tauri_specta::Event)]
+#[serde(rename_all = "camelCase")]
+pub struct AddAssetDeepLink {
+    path: PathBuf,
+    booth_item_id: Option<u64>,
+}
+
+impl AddAssetDeepLink {
+    pub fn new(path: PathBuf, booth_item_id: Option<u64>) -> Self {
+        Self {
+            path,
+            booth_item_id,
+        }
+    }
+}

--- a/src-tauri/src/deep_link/executer.rs
+++ b/src-tauri/src/deep_link/executer.rs
@@ -1,0 +1,16 @@
+use tauri::AppHandle;
+use tauri_specta::Event;
+
+use super::definitions::DeepLinkAction;
+
+pub fn execute_deep_links(app: &AppHandle, deep_links: &Vec<DeepLinkAction>) {
+    for deep_link in deep_links {
+        match deep_link {
+            DeepLinkAction::AddAsset(info) => {
+                if let Err(e) = info.emit(app) {
+                    log::error!("Failed to emit add asset event: {}", e);
+                }
+            }
+        }
+    }
+}

--- a/src-tauri/src/deep_link/mod.rs
+++ b/src-tauri/src/deep_link/mod.rs
@@ -1,0 +1,15 @@
+use definitions::DeepLinkAction;
+use tauri::AppHandle;
+
+pub mod definitions;
+
+mod executer;
+mod parser;
+
+pub fn parse_args_to_deep_links(args: &Vec<String>) -> Vec<DeepLinkAction> {
+    parser::parse(args)
+}
+
+pub fn execute_deep_links(app: &AppHandle, deep_links: &Vec<DeepLinkAction>) {
+    executer::execute_deep_links(app, deep_links);
+}

--- a/src-tauri/src/deep_link/parser.rs
+++ b/src-tauri/src/deep_link/parser.rs
@@ -1,0 +1,78 @@
+use std::path::PathBuf;
+
+use tauri::Url;
+
+use super::definitions::{AddAssetDeepLink, DeepLinkAction};
+
+pub fn parse(args: &Vec<String>) -> Vec<DeepLinkAction> {
+    if args.len() < 2 {
+        return vec![];
+    }
+
+    let mut deep_links = vec![];
+
+    for i in 1..args.len() {
+        let arg = &args[i];
+
+        let result = Url::parse(&arg);
+        if result.is_err() {
+            continue;
+        }
+
+        let url = result.unwrap();
+        let domain = url.domain();
+
+        if domain.is_none() {
+            continue;
+        }
+        let domain = domain.unwrap();
+
+        match domain {
+            "add-asset" | "addAsset" => {
+                let deep_link_info = parse_as_add_asset(&url);
+
+                if let Some(info) = deep_link_info {
+                    deep_links.push(DeepLinkAction::AddAsset(info));
+                }
+            }
+            _ => {
+                log::warn!("Unknown domain: {}", domain);
+            }
+        }
+    }
+
+    deep_links
+}
+
+fn parse_as_add_asset(url: &Url) -> Option<AddAssetDeepLink> {
+    let queries = url.query_pairs();
+
+    let mut path = None;
+    let mut booth_item_id = None;
+
+    for (key, value) in queries {
+        match key.to_ascii_lowercase().as_ref() {
+            "path" | "dir" | "file" => {
+                path = Some(PathBuf::from(value.as_ref()));
+            }
+            "id" | "boothid" | "boothitemid" => {
+                let id = value.parse::<u64>();
+
+                if let Err(e) = id {
+                    log::error!("Unable to parse booth item id: {}", e);
+                    continue;
+                }
+
+                booth_item_id = Some(id.unwrap());
+            }
+            _ => {}
+        }
+    }
+
+    if path.is_none() {
+        log::error!("Path is not specified in add-asset deep link");
+        return None;
+    }
+
+    Some(AddAssetDeepLink::new(path.unwrap(), booth_item_id))
+}

--- a/src-tauri/src/deep_link/parser.rs
+++ b/src-tauri/src/deep_link/parser.rs
@@ -59,7 +59,11 @@ fn parse_as_add_asset(url: &Url) -> Option<AddAssetDeepLink> {
                 let id = value.parse::<u64>();
 
                 if let Err(e) = id {
-                    log::error!("Unable to parse booth item id: {}", e);
+                    log::error!(
+                        "Unable to parse {} into booth item id: {}",
+                        value.as_ref(),
+                        e
+                    );
                     continue;
                 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,11 +3,16 @@ use std::{path::PathBuf, sync::Arc};
 use booth::{fetcher::BoothFetcher, image_resolver::PximgResolver};
 use command::generate_tauri_specta_builder;
 use data_store::{delete::delete_temporary_images, provider::StoreProvider};
+use deep_link::{
+    definitions::{AddAssetDeepLink, StartupDeepLinkStore},
+    execute_deep_links, parse_args_to_deep_links,
+};
 use definitions::entities::{InitialSetup, LoadResult, ProgressEvent};
 use language::load::load_from_language_code;
 use preference::store::PreferenceStore;
 use task::{cancellable_task::TaskContainer, definitions::TaskStatusChanged};
 use tauri::{async_runtime::Mutex, AppHandle, Manager};
+use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_specta::collect_events;
 use updater::update_handler::{UpdateChannel, UpdateHandler};
 
@@ -18,6 +23,7 @@ mod adapter;
 mod booth;
 mod command;
 mod data_store;
+mod deep_link;
 mod definitions;
 mod file;
 mod importer;
@@ -33,8 +39,11 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let builder =
-        generate_tauri_specta_builder().events(collect_events![ProgressEvent, TaskStatusChanged,]);
+    let builder = generate_tauri_specta_builder().events(collect_events![
+        ProgressEvent,
+        TaskStatusChanged,
+        AddAssetDeepLink
+    ]);
 
     #[cfg(debug_assertions)]
     builder
@@ -50,11 +59,14 @@ pub fn run() {
 
     #[cfg(desktop)]
     {
-        tauri_builder = tauri_builder.plugin(tauri_plugin_single_instance::init(|app, _, _| {
+        tauri_builder = tauri_builder.plugin(tauri_plugin_single_instance::init(|app, args, _| {
             let _ = app
                 .get_webview_window("main")
                 .expect("no main window")
                 .set_focus();
+
+            let deep_links = parse_args_to_deep_links(&args);
+            execute_deep_links(&app, &deep_links);
         }));
     }
 
@@ -62,6 +74,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_deep_link::init())
         .invoke_handler(builder.invoke_handler())
         .manage(Mutex::new(BoothFetcher::new()))
         .manage(Arc::new(Mutex::new(TaskContainer::new())))
@@ -72,6 +85,19 @@ pub fn run() {
             set_window_title(app.handle(), format!("KonoAsset v{}", VERSION));
 
             app.manage(app.handle().clone());
+
+            #[cfg(any(windows, target_os = "linux"))]
+            {
+                if let Err(e) = app.deep_link().register_all() {
+                    log::error!("Failed to register deep links: {}", e);
+                }
+            }
+
+            let args = std::env::args().collect::<Vec<_>>();
+            let deep_links = parse_args_to_deep_links(&args);
+            let deep_links = StartupDeepLinkStore::new(deep_links);
+
+            app.manage(arc_mutex(deep_links));
 
             let preference_file_path = app
                 .path()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -48,6 +48,11 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEVENjIwRUZCQjg1Rjk0RjUKUldUMWxGKzQrdzVpN1hlT0hrcEpaK0Q1RXFKVzF2YXMzNFJZVDBVSHh6djJNNU1zQ2hMR05oTHYK",
       "endpoints": ["https://releases.konoasset.dev/manifests/latest.json"]
+    },
+    "deep-link": {
+      "desktop": {
+        "schemes": ["konoasset"]
+      }
     }
   }
 }

--- a/src/components/model/asset-dialogs/AddAssetDialog/hook/index.ts
+++ b/src/components/model/asset-dialogs/AddAssetDialog/hook/index.ts
@@ -46,7 +46,9 @@ const useAddAssetDialog = ({
   >([])
   const [importTaskId, setImportTaskId] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
-  const [ignoreFormClearCount, setIgnoreFormClearCount] = useState(0)
+
+  // 1以上の場合、その回数だけフォームのリセットを行わずにダイアログを開く
+  const [formClearSuppressionCount, setFormClearSuppressionCount] = useState(0)
 
   const { toast } = useToast()
   const { t } = useLocalization()
@@ -119,7 +121,7 @@ const useAddAssetDialog = ({
       return
     }
 
-    setIgnoreFormClearCount((prev) => prev + 1)
+    setFormClearSuppressionCount((prev) => prev + 1)
     setDialogOpen(true)
   }
 
@@ -183,8 +185,8 @@ const useAddAssetDialog = ({
   }, [])
 
   useEffect(() => {
-    if (ignoreFormClearCount > 0) {
-      setIgnoreFormClearCount((prev) => prev - 1)
+    if (formClearSuppressionCount > 0) {
+      setFormClearSuppressionCount((prev) => prev - 1)
       return
     }
 

--- a/src/components/model/asset-dialogs/components/tabs/BoothInputTab/add/hook/index.test.ts
+++ b/src/components/model/asset-dialogs/components/tabs/BoothInputTab/add/hook/index.test.ts
@@ -42,7 +42,9 @@ vi.mock('@/hooks/use-toast', () => {
 
 describe('BoothInputTab Hook', () => {
   it('executes getAssetDescriptionFromBooth function correctly', async () => {
-    const mockForm = {}
+    const mockForm = {
+      getValues: vi.fn().mockReturnValue(null),
+    }
     const mockSetTab = vi.fn()
     const mockToast = useToast().toast as Mock
 
@@ -98,7 +100,9 @@ describe('BoothInputTab Hook', () => {
   })
 
   it('executes backToPreviousTab function correctly', async () => {
-    const mockForm = {}
+    const mockForm = {
+      getValues: vi.fn().mockReturnValue(null),
+    }
     const mockSetTab = vi.fn()
 
     const { result } = renderHook(() =>

--- a/src/components/model/asset-dialogs/components/tabs/BoothInputTab/add/hook/index.test.ts
+++ b/src/components/model/asset-dialogs/components/tabs/BoothInputTab/add/hook/index.test.ts
@@ -41,6 +41,34 @@ vi.mock('@/hooks/use-toast', () => {
 })
 
 describe('BoothInputTab Hook', () => {
+  it('correctly maintains the URL input value', () => {
+    const mockForm = {
+      getValues: vi.fn().mockReturnValue(null),
+    }
+    const mockSetTab = vi.fn()
+
+    const { result } = renderHook(() =>
+      useBoothInputTabForAddDialog({
+        // @ts-expect-error mockForm is not a valid AssetFormType but satisfies the required fields
+        form: mockForm,
+        setTab: mockSetTab,
+      }),
+    )
+
+    // Initial state should be empty
+    expect(result.current.boothUrlInput).toBe('')
+
+    // Update URL value
+    const url = 'https://booth.pm/ja/items/12345'
+
+    act(() => {
+      result.current.onUrlInputChange({
+        target: { value: url },
+      } as React.ChangeEvent<HTMLInputElement>)
+    })
+    expect(result.current.boothUrlInput).toBe(url)
+  })
+
   it('executes getAssetDescriptionFromBooth function correctly', async () => {
     const mockForm = {
       getValues: vi.fn().mockReturnValue(null),

--- a/src/components/model/asset-dialogs/components/tabs/BoothInputTab/add/hook/index.ts
+++ b/src/components/model/asset-dialogs/components/tabs/BoothInputTab/add/hook/index.ts
@@ -1,5 +1,5 @@
-import { extractBoothItemId } from '@/lib/utils'
-import { useState, useContext, ChangeEvent } from 'react'
+import { convertToBoothURL, extractBoothItemId } from '@/lib/utils'
+import { useState, useContext, ChangeEvent, useEffect } from 'react'
 import { AddAssetDialogContext } from '../../../../../AddAssetDialog'
 import { sep } from '@tauri-apps/api/path'
 import { AssetFormType } from '@/lib/form'
@@ -39,6 +39,15 @@ export const useBoothInputTabForAddDialog = ({
   const { assetPaths, setDuplicateWarningItems } = useContext(
     AddAssetDialogContext,
   )
+
+  useEffect(() => {
+    const boothItemId = form.getValues('boothItemId')
+
+    if (boothItemId !== null) {
+      setBoothItemId(boothItemId)
+      setBoothUrlInput(convertToBoothURL(boothItemId))
+    }
+  }, [])
 
   const backToPreviousTab = () => {
     setTab('selector')

--- a/src/components/model/asset-dialogs/components/tabs/BoothInputTab/add/index.test.tsx
+++ b/src/components/model/asset-dialogs/components/tabs/BoothInputTab/add/index.test.tsx
@@ -1,9 +1,8 @@
 import { afterEach, describe, expect, it, Mock, vi } from 'vitest'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import BoothInputTab from '.'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
 import { useBoothInputTabForAddDialog } from './hook'
-import { setupAndRender } from '@/test/init'
 
 vi.mock('./hook', () => {
   return {
@@ -39,52 +38,6 @@ describe('BoothInputTab', () => {
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
-  })
-
-  it('handles button clicks and keyboard input correctly', async () => {
-    const mockForm = {
-      watch: vi.fn().mockReturnValue('Avatar'),
-      setValue: vi.fn(),
-    }
-    const mockSetTab = vi.fn()
-
-    const mockUseBoothInputTab = useBoothInputTabForAddDialog as Mock
-    mockUseBoothInputTab.mockReturnValueOnce(base)
-
-    const { user } = setupAndRender(
-      <Dialog open={true}>
-        <DialogContent>
-          <BoothInputTab
-            // @ts-expect-error type check fails but it satisfies the required fields
-            form={mockForm}
-            setTab={mockSetTab}
-          />
-        </DialogContent>
-      </Dialog>,
-    )
-
-    const { backToPreviousTab, moveToNextTab, onUrlInputChange } = base
-
-    // Check back button works correctly
-    fireEvent.click(screen.getByText('general:button:back'))
-    expect(backToPreviousTab).toHaveBeenCalledOnce()
-
-    // Check skip button works correctly
-    fireEvent.click(screen.getByText('addasset:booth-input:manual-input'))
-    expect(moveToNextTab).toHaveBeenCalledOnce()
-
-    const inputTarget = screen.getByPlaceholderText(
-      'https://booth.pm/ja/items/1234567',
-    )
-
-    // Check input change works correctly
-    const inputText = 'https://booth.pm/ja/items/1234567'
-    await user.type(inputTarget, inputText)
-
-    expect(onUrlInputChange).toHaveBeenCalledTimes(inputText.length)
-    expect(
-      onUrlInputChange.mock.calls[inputText.length - 1][0].target.value,
-    ).toEqual(inputText)
   })
 
   it('renders fetch button as disabled when URL is invalid', async () => {

--- a/src/components/model/asset-dialogs/components/tabs/BoothInputTab/add/index.tsx
+++ b/src/components/model/asset-dialogs/components/tabs/BoothInputTab/add/index.tsx
@@ -78,6 +78,7 @@ const BoothInputTabForAddDialog = ({
           <div className="flex flex-row items-center mt-1 space-x-2">
             <Input
               placeholder="https://booth.pm/ja/items/1234567"
+              value={boothUrlInput}
               onChange={onUrlInputChange}
               disabled={fetching}
             />

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -411,6 +411,14 @@ async loadLanguageFile(path: string) : Promise<Result<LocalizationData, string>>
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async requestStartupDeepLinkExecution() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("request_startup_deep_link_execution") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -418,9 +426,11 @@ async loadLanguageFile(path: string) : Promise<Result<LocalizationData, string>>
 
 
 export const events = __makeEvents__<{
+addAssetDeepLink: AddAssetDeepLink,
 progressEvent: ProgressEvent,
 taskStatusChanged: TaskStatusChanged
 }>({
+addAssetDeepLink: "add-asset-deep-link",
 progressEvent: "progress-event",
 taskStatusChanged: "task-status-changed"
 })
@@ -431,6 +441,7 @@ taskStatusChanged: "task-status-changed"
 
 /** user-defined types **/
 
+export type AddAssetDeepLink = { path: string; boothItemId: number | null }
 export type AssetDescription = { name: string; creator: string; imageFilename: string | null; tags: string[]; memo: string | null; boothItemId: number | null; dependencies: string[]; createdAt: number; publishedAt: number | null }
 export type AssetImportRequest<T> = { preAsset: T; absolutePaths: string[]; deleteSource: boolean }
 export type AssetSummary = { id: string; assetType: AssetType; name: string; creator: string; imageFilename: string | null; hasMemo: boolean; dependencies: string[]; boothItemId: number | null; publishedAt: number | null }


### PR DESCRIPTION
`konoasset://addAsset?dir=path-to-file&id=12345` のようなURLでアプリが開き、アセット追加ダイアログが表示される機能を実装

Close #274