### PR TITLE
アップデートの進行状況をプログレスバーで表示する機能の実装

### DIFF
--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -282,7 +282,7 @@
     "top:update-dialog:description": "Downloading update...",
     "top:update-dialog:downloading:foretext": "Downloading (",
     "top:update-dialog:downloading:posttext": "%)",
-    "top:update-dialog:download-complete": "Downloaded update",
+    "top:update-dialog:download-complete": "Update downloaded",
     "top:update-dialog:execute": "Update",
   
     "top:add-text": "Drop files to add assets",

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -278,6 +278,13 @@
     "top:new-update-toast:button": "Update now",
     "top:new-update-toast:close": "Not now",
 
+    "top:update-dialog:title": "Preparing update",
+    "top:update-dialog:description": "Downloading update...",
+    "top:update-dialog:downloading:foretext": "Downloading (",
+    "top:update-dialog:downloading:posttext": "%)",
+    "top:update-dialog:download-complete": "Downloaded update",
+    "top:update-dialog:execute": "Update",
+  
     "top:add-text": "Drop files to add assets",
 
     "setup:welcome": "Welcome to KonoAsset!",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -282,7 +282,7 @@
     "top:update-dialog:description": "Downloading update...",
     "top:update-dialog:downloading:foretext": "Downloading (",
     "top:update-dialog:downloading:posttext": "%)",
-    "top:update-dialog:download-complete": "Downloaded update",
+    "top:update-dialog:download-complete": "Update downloaded",
     "top:update-dialog:execute": "Update",
 
     "top:add-text": "Drop files to add assets",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -278,6 +278,13 @@
     "top:new-update-toast:button": "Update now",
     "top:new-update-toast:close": "Not now",
 
+    "top:update-dialog:title": "Preparing update",
+    "top:update-dialog:description": "Downloading update...",
+    "top:update-dialog:downloading:foretext": "Downloading (",
+    "top:update-dialog:downloading:posttext": "%)",
+    "top:update-dialog:download-complete": "Downloaded update",
+    "top:update-dialog:execute": "Update",
+
     "top:add-text": "Drop files to add assets",
 
     "setup:welcome": "Welcome to KonoAsset!",

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -278,6 +278,13 @@
     "top:new-update-toast:button": "アップデートする",
     "top:new-update-toast:close": "今はしない",
 
+    "top:update-dialog:title": "アップデートを準備中",
+    "top:update-dialog:description": "アップデートをダウンロードしています...",
+    "top:update-dialog:downloading:foretext": "ダウンロード中 (",
+    "top:update-dialog:downloading:posttext": "%)",
+    "top:update-dialog:download-complete": "アップデートをダウンロード済み",
+    "top:update-dialog:execute": "アップデート",
+
     "top:add-text": "ファイルをドロップしてアセットを追加",
 
     "setup:welcome": "KonoAssetへようこそ！",

--- a/src-tauri/src/command/mod.rs
+++ b/src-tauri/src/command/mod.rs
@@ -40,7 +40,8 @@ pub fn generate_tauri_specta_builder() -> Builder<tauri::Wry> {
         external::booth::resolve_pximg_filename,
         // アップデート関連
         update::common::check_for_update,
-        update::common::execute_update,
+        update::common::download_update,
+        update::common::install_update,
         update::common::do_not_notify_update,
         // ファイル関連
         file::open::open_file_in_file_manager,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,7 +14,7 @@ use task::{cancellable_task::TaskContainer, definitions::TaskStatusChanged};
 use tauri::{async_runtime::Mutex, AppHandle, Manager};
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_specta::collect_events;
-use updater::update_handler::{UpdateChannel, UpdateHandler};
+use updater::update_handler::{UpdateChannel, UpdateHandler, UpdateProgress};
 
 #[cfg(debug_assertions)]
 use specta_typescript::{BigIntExportBehavior, Typescript};
@@ -42,7 +42,8 @@ pub fn run() {
     let builder = generate_tauri_specta_builder().events(collect_events![
         ProgressEvent,
         TaskStatusChanged,
-        AddAssetDeepLink
+        AddAssetDeepLink,
+        UpdateProgress,
     ]);
 
     #[cfg(debug_assertions)]

--- a/src/components/context/PersistentContext/logic/index.test.ts
+++ b/src/components/context/PersistentContext/logic/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, Mock, vi } from 'vitest'
-import { checkForUpdate, dismissUpdate, executeUpdate, refreshAssets } from '.'
+import { refreshAssets } from '.'
 import { AssetSummary, commands, SortBy } from '@/lib/bindings'
 
 const mockSortedAssets: AssetSummary[] = [
@@ -78,35 +78,5 @@ describe('PersistentContext Logic', () => {
     expect(mockedCommand.mock.calls[0][0]).toEqual(sortBy)
 
     expect(setAssetDisplaySortedList).not.toHaveBeenCalled()
-  })
-
-  it('executes checkForUpdate function correctly', async () => {
-    const mockedCommand = commands.checkForUpdate as Mock
-
-    const result1 = await checkForUpdate()
-    expect(mockedCommand).toHaveBeenCalledTimes(1)
-    expect(result1).toEqual(true)
-
-    const result2 = await checkForUpdate()
-    expect(mockedCommand).toHaveBeenCalledTimes(2)
-    expect(result2).toEqual(false)
-
-    const result3 = await checkForUpdate()
-    expect(mockedCommand).toHaveBeenCalledTimes(3)
-    expect(result3).toEqual(false)
-  })
-
-  it('executes executeUpdate function correctly', async () => {
-    await executeUpdate()
-
-    const mockedCommand = commands.executeUpdate as Mock
-    expect(mockedCommand).toHaveBeenCalledOnce()
-  })
-
-  it('executes dismissUpdate function correctly', async () => {
-    await dismissUpdate()
-
-    const mockedCommand = commands.doNotNotifyUpdate as Mock
-    expect(mockedCommand).toHaveBeenCalledOnce()
   })
 })

--- a/src/components/context/PersistentContext/logic/index.ts
+++ b/src/components/context/PersistentContext/logic/index.ts
@@ -12,16 +12,3 @@ export const refreshAssets = async (
     console.error(result.error)
   }
 }
-
-export const checkForUpdate = async (): Promise<boolean> => {
-  const result = await commands.checkForUpdate()
-  return result.status === 'ok' && result.data
-}
-
-export const executeUpdate = async () => {
-  await commands.executeUpdate()
-}
-
-export const dismissUpdate = async () => {
-  await commands.doNotNotifyUpdate()
-}

--- a/src/components/model/UpdateDialog/hook/index.ts
+++ b/src/components/model/UpdateDialog/hook/index.ts
@@ -1,0 +1,156 @@
+import { useLocalization } from '@/hooks/use-localization'
+import { useToast } from '@/hooks/use-toast'
+import { events, commands } from '@/lib/bindings'
+import { UnlistenFn } from '@tauri-apps/api/event'
+import { useEffect, useState } from 'react'
+
+type Props = {
+  setDialogOpen: (open: boolean) => void
+  taskId: string | null
+}
+
+type ReturnProps = {
+  progress: number
+  onCancelButtonClick: () => Promise<void>
+  onUpdateButtonClick: () => Promise<void>
+}
+
+export const useUpdateDialog = ({
+  setDialogOpen,
+  taskId,
+}: Props): ReturnProps => {
+  const [progress, setProgress] = useState(0)
+
+  const { toast } = useToast()
+  const { t } = useLocalization()
+
+  const onCancelButtonClick = async () => {
+    if (taskId !== null) {
+      const result = await commands.cancelTaskRequest(taskId)
+      if (result.status === 'error') {
+        console.error('Failed to cancel task:', result.error)
+      }
+    }
+
+    setDialogOpen(false)
+    toast({
+      title: t('general:cancelled'),
+    })
+  }
+
+  const onUpdateButtonClick = async () => {
+    const result = await commands.installUpdate()
+
+    if (result.status === 'error') {
+      console.error('Failed to install update:', result.error)
+    }
+  }
+
+  useEffect(() => {
+    let isCancelled = false
+    let callbackExecuted = false
+    let unlistenProgressFn: UnlistenFn | undefined = undefined
+    let unlistenCompleteFn: UnlistenFn | undefined = undefined
+
+    const setupListener = async () => {
+      try {
+        unlistenCompleteFn = await events.taskStatusChanged.listen((e) => {
+          if (isCancelled) return
+
+          const completedTaskId = e.payload.id
+          const status = e.payload.status
+
+          if (
+            callbackExecuted ||
+            completedTaskId !== taskId ||
+            status === 'Running'
+          ) {
+            return
+          }
+
+          callbackExecuted = true
+          if (status === 'Completed') {
+            setProgress(100)
+          } else if (status === 'Cancelled') {
+            onCancelButtonClick()
+          } else if (status === 'Failed') {
+            commands.getTaskError(taskId).then((result) => {
+              if (result.status === 'ok') {
+                toast({
+                  title: t('general:failed'),
+                  description: result.data,
+                })
+              } else {
+                console.error('Failed to get task error:', result.error)
+              }
+            })
+          }
+        })
+
+        if (isCancelled) {
+          unlistenCompleteFn()
+          return
+        }
+
+        unlistenProgressFn = await events.updateProgress.listen((e) => {
+          if (isCancelled) return
+
+          setProgress(e.payload.progress * 100)
+        })
+
+        if (isCancelled) {
+          unlistenProgressFn()
+          unlistenCompleteFn()
+          return
+        }
+
+        if (taskId === null || callbackExecuted) {
+          return
+        }
+
+        const result = await commands.getTaskStatus(taskId)
+
+        if (result.status === 'error') {
+          console.error('Failed to get task status:', result.error)
+          return
+        }
+
+        if (result.data === 'Completed') {
+          setProgress(100)
+        } else if (result.data === 'Cancelled') {
+          onCancelButtonClick()
+        } else if (result.data === 'Failed') {
+          const result = await commands.getTaskError(taskId)
+
+          if (result.status === 'ok') {
+            toast({
+              title: t('general:failed'),
+              description: result.data,
+            })
+          } else {
+            console.error('Failed to get task error:', result.error)
+          }
+        }
+      } catch (error) {
+        console.error(
+          'Failed to listen to TaskCompleted and ImportProgress event:',
+          error,
+        )
+      }
+    }
+
+    setupListener()
+
+    return () => {
+      isCancelled = true
+      unlistenProgressFn?.()
+      unlistenCompleteFn?.()
+    }
+  }, [taskId])
+
+  return {
+    progress,
+    onCancelButtonClick,
+    onUpdateButtonClick,
+  }
+}

--- a/src/components/model/UpdateDialog/index.tsx
+++ b/src/components/model/UpdateDialog/index.tsx
@@ -53,7 +53,7 @@ export const UpdateDialog: FC<Props> = ({
             {progress < 100 && (
               <span>
                 {t('top:update-dialog:downloading:foretext')}
-                {progress}
+                {Math.round(progress * 100) / 100}
                 {t('top:update-dialog:downloading:posttext')}
               </span>
             )}

--- a/src/components/model/UpdateDialog/index.tsx
+++ b/src/components/model/UpdateDialog/index.tsx
@@ -1,0 +1,78 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Progress } from '@/components/ui/progress'
+import { FC } from 'react'
+import { useLocalization } from '@/hooks/use-localization'
+import { useUpdateDialog } from './hook'
+
+type Props = {
+  dialogOpen: boolean
+  setDialogOpen: (open: boolean) => void
+  taskId: string | null
+}
+
+export const UpdateDialog: FC<Props> = ({
+  dialogOpen,
+  setDialogOpen,
+  taskId,
+}) => {
+  const { t } = useLocalization()
+
+  const { progress, onCancelButtonClick, onUpdateButtonClick } =
+    useUpdateDialog({
+      setDialogOpen,
+      taskId,
+    })
+
+  return (
+    <Dialog open={dialogOpen}>
+      <DialogContent
+        className="max-w-[600px] [&>button]:hidden"
+        onInteractOutside={(e) => {
+          e.preventDefault()
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>アップデートを準備中</DialogTitle>
+          <DialogDescription>
+            アップデートをダウンロードしています...
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-1 w-full overflow-hidden">
+          <p className="text-muted-foreground">
+            {progress >= 100 && <span>アップデートをダウンロード済み</span>}
+            {progress < 100 && <span>"ダウンロード中 ({progress}%)"</span>}
+          </p>
+          <Progress value={progress} />
+        </div>
+        <DialogFooter className="mt-4">
+          <div className="w-full max-w-72 flex justify-between mx-auto">
+            <Button
+              variant="secondary"
+              className="mr-auto"
+              onClick={onCancelButtonClick}
+            >
+              {t('general:button:cancel')}
+            </Button>
+            <div className="relative">
+              <Button
+                className="ml-auto"
+                disabled={progress < 100}
+                onClick={onUpdateButtonClick}
+              >
+                アップデート
+              </Button>
+            </div>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/model/UpdateDialog/index.tsx
+++ b/src/components/model/UpdateDialog/index.tsx
@@ -69,15 +69,13 @@ export const UpdateDialog: FC<Props> = ({
             >
               {t('general:button:cancel')}
             </Button>
-            <div className="relative">
-              <Button
-                className="ml-auto"
-                disabled={progress < 100}
-                onClick={onUpdateButtonClick}
-              >
-                {t('top:update-dialog:execute')}
-              </Button>
-            </div>
+            <Button
+              className="ml-auto"
+              disabled={progress < 100}
+              onClick={onUpdateButtonClick}
+            >
+              {t('top:update-dialog:execute')}
+            </Button>
           </div>
         </DialogFooter>
       </DialogContent>

--- a/src/components/model/UpdateDialog/index.tsx
+++ b/src/components/model/UpdateDialog/index.tsx
@@ -40,15 +40,23 @@ export const UpdateDialog: FC<Props> = ({
         }}
       >
         <DialogHeader>
-          <DialogTitle>アップデートを準備中</DialogTitle>
+          <DialogTitle>{t('top:update-dialog:title')}</DialogTitle>
           <DialogDescription>
-            アップデートをダウンロードしています...
+            {t('top:update-dialog:description')}
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-1 w-full overflow-hidden">
           <p className="text-muted-foreground">
-            {progress >= 100 && <span>アップデートをダウンロード済み</span>}
-            {progress < 100 && <span>"ダウンロード中 ({progress}%)"</span>}
+            {progress >= 100 && (
+              <span>{t('top:update-dialog:download-complete')}</span>
+            )}
+            {progress < 100 && (
+              <span>
+                {t('top:update-dialog:downloading:foretext')}
+                {progress}
+                {t('top:update-dialog:downloading:posttext')}
+              </span>
+            )}
           </p>
           <Progress value={progress} />
         </div>
@@ -67,7 +75,7 @@ export const UpdateDialog: FC<Props> = ({
                 disabled={progress < 100}
                 onClick={onUpdateButtonClick}
               >
-                アップデート
+                {t('top:update-dialog:execute')}
               </Button>
             </div>
           </div>

--- a/src/components/page/Top/hook.tsx
+++ b/src/components/page/Top/hook.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useContext } from 'react'
 import {
   checkForUpdate,
   dismissUpdate,
-  executeUpdate,
+  downloadUpdate,
   onFileDrop,
   refreshAssets,
 } from './logic'
@@ -18,6 +18,20 @@ import { useLocalization } from '@/hooks/use-localization'
 type ReturnProps = {
   assetContextValue: AssetContextType
   isDragAndHover: boolean
+  displayAssetCount: number | undefined
+  matchedAssetIDs: string[]
+  setMatchedAssetIDs: (uuidList: string[]) => void
+  filterEnforced: boolean
+  setFilterEnforced: (filterEnforced: boolean) => void
+  addAssetDialogOpen: boolean
+  setAddAssetDialogOpen: (open: boolean) => void
+  setEditAssetDialogAssetId: (assetId: string | null) => void
+  setEditAssetDialogOpen: (open: boolean) => void
+  editAssetDialogAssetId: string | null
+  editAssetDialogOpen: boolean
+  updateDialogOpen: boolean
+  setUpdateDialogOpen: (open: boolean) => void
+  updateDownloadTaskId: string | null
 }
 
 export const useTopPage = (): ReturnProps => {
@@ -25,11 +39,28 @@ export const useTopPage = (): ReturnProps => {
   const [assetDisplaySortedList, setAssetDisplaySortedList] = useState<
     AssetSummary[]
   >([])
+  const [filterEnforced, setFilterEnforced] = useState(false)
+  const [matchedAssetIDs, setMatchedAssetIDs] = useState<string[]>([])
+  const [addAssetDialogOpen, setAddAssetDialogOpen] = useState(false)
+
+  const [editAssetDialogOpen, setEditAssetDialogOpen] = useState(false)
+  const [editAssetDialogAssetId, setEditAssetDialogAssetId] = useState<
+    string | null
+  >(null)
+
+  const [updateDialogOpen, setUpdateDialogOpen] = useState(false)
+  const [updateDownloadTaskId, setUpdateDownloadTaskId] = useState<
+    string | null
+  >(null)
 
   const [isDragAndHover, setDragAndHover] = useState(false)
 
   const { t } = useLocalization()
   const { toast } = useToast()
+
+  const displayAssetCount: number | undefined = filterEnforced
+    ? matchedAssetIDs.length
+    : undefined
 
   const assetContextValue: AssetContextType = {
     assetDisplaySortedList: assetDisplaySortedList,
@@ -54,42 +85,66 @@ export const useTopPage = (): ReturnProps => {
     onFileDrop(event, setDragAndHover)
   })
 
+  const startUpdateDownloadingAndOpenDialog = async () => {
+    await downloadUpdate(setUpdateDownloadTaskId)
+    setUpdateDialogOpen(true)
+  }
+
   const executeUpdateCheck = async () => {
     const updateAvailable = await checkForUpdate()
 
-    if (updateAvailable) {
-      toast({
-        title: t('top:new-update-toast'),
-        description: t('top:new-update-toast:description'),
-        duration: 30000,
-        onSwipeEnd: () => {
-          dismissUpdate()
-        },
-        action: (
-          <div className="flex flex-col space-y-2">
-            <ToastAction
-              altText="Ignore update"
-              className={buttonVariants({ variant: 'default' })}
-              onClick={executeUpdate}
-            >
-              {t('top:new-update-toast:button')}
-            </ToastAction>
-            <ToastAction
-              altText="Ignore update"
-              className={buttonVariants({ variant: 'outline' })}
-              onClick={() => dismissUpdate()}
-            >
-              {t('top:new-update-toast:close')}
-            </ToastAction>
-          </div>
-        ),
-      })
+    if (!updateAvailable) {
+      return
     }
+
+    toast({
+      title: t('top:new-update-toast'),
+      description: t('top:new-update-toast:description'),
+      duration: 30000,
+      onSwipeEnd: () => {
+        dismissUpdate()
+      },
+      action: (
+        <div className="flex flex-col space-y-2">
+          <ToastAction
+            altText="Open update dialog"
+            className={buttonVariants({ variant: 'default' })}
+            onClick={startUpdateDownloadingAndOpenDialog}
+          >
+            {t('top:new-update-toast:button')}
+          </ToastAction>
+          <ToastAction
+            altText="Ignore update"
+            className={buttonVariants({ variant: 'outline' })}
+            onClick={() => dismissUpdate()}
+          >
+            {t('top:new-update-toast:close')}
+          </ToastAction>
+        </div>
+      ),
+    })
   }
 
   useEffect(() => {
     executeUpdateCheck()
   }, [])
 
-  return { assetContextValue, isDragAndHover }
+  return {
+    assetContextValue,
+    isDragAndHover,
+    displayAssetCount,
+    matchedAssetIDs,
+    setMatchedAssetIDs,
+    filterEnforced,
+    setFilterEnforced,
+    addAssetDialogOpen,
+    setAddAssetDialogOpen,
+    setEditAssetDialogAssetId,
+    setEditAssetDialogOpen,
+    editAssetDialogAssetId,
+    editAssetDialogOpen,
+    updateDialogOpen,
+    setUpdateDialogOpen,
+    updateDownloadTaskId,
+  }
 }

--- a/src/components/page/Top/index.tsx
+++ b/src/components/page/Top/index.tsx
@@ -3,28 +3,32 @@ import MainSidebar from '@/components/model/MainSidebar'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { cn } from '@/lib/utils'
 import { useTopPage } from './hook'
-import { useState } from 'react'
 import NavBar from '../../model/MainNavBar'
 import AssetList from '@/components/model/AssetList'
 import AddAssetDialog from '@/components/model/asset-dialogs/AddAssetDialog'
 import EditAssetDialog from '@/components/model/asset-dialogs/EditAssetDialog'
 import { useLocalization } from '@/hooks/use-localization'
+import { UpdateDialog } from '@/components/model/UpdateDialog'
 
 const TopPage = () => {
-  const { assetContextValue, isDragAndHover } = useTopPage()
-
-  const [filterEnforced, setFilterEnforced] = useState(false)
-  const [matchedAssetIDs, setMatchedAssetIDs] = useState<string[]>([])
-  const [dialogOpen, setDialogOpen] = useState(false)
-
-  const [editAssetDialogOpen, setEditAssetDialogOpen] = useState(false)
-  const [editAssetDialogAssetId, setEditAssetDialogAssetId] = useState<
-    string | null
-  >(null)
-
-  const displayAssetCount: number | undefined = filterEnforced
-    ? matchedAssetIDs.length
-    : undefined
+  const {
+    assetContextValue,
+    isDragAndHover,
+    displayAssetCount,
+    matchedAssetIDs,
+    setMatchedAssetIDs,
+    filterEnforced,
+    setFilterEnforced,
+    addAssetDialogOpen,
+    setAddAssetDialogOpen,
+    setEditAssetDialogAssetId,
+    setEditAssetDialogOpen,
+    editAssetDialogAssetId,
+    editAssetDialogOpen,
+    updateDialogOpen,
+    setUpdateDialogOpen,
+    updateDownloadTaskId,
+  } = useTopPage()
 
   const { t } = useLocalization()
 
@@ -41,13 +45,13 @@ const TopPage = () => {
               setMatchedAssetIDs={setMatchedAssetIDs}
               filterEnforced={filterEnforced}
               setFilterEnforced={setFilterEnforced}
-              openAddAssetDialog={() => setDialogOpen(true)}
+              openAddAssetDialog={() => setAddAssetDialogOpen(true)}
             />
             <AddAssetDialog
-              dialogOpen={dialogOpen}
-              setDialogOpen={setDialogOpen}
+              dialogOpen={addAssetDialogOpen}
+              setDialogOpen={setAddAssetDialogOpen}
               openEditDialog={(assetId) => {
-                setDialogOpen(false)
+                setAddAssetDialogOpen(false)
 
                 setEditAssetDialogAssetId(assetId)
                 setEditAssetDialogOpen(true)
@@ -61,6 +65,11 @@ const TopPage = () => {
           </main>
         </SidebarProvider>
       </AssetContext.Provider>
+      <UpdateDialog
+        dialogOpen={updateDialogOpen}
+        setDialogOpen={setUpdateDialogOpen}
+        taskId={updateDownloadTaskId}
+      />
       <div
         className={cn(
           'fixed h-full w-full opacity-0 z-[60] pointer-events-none transition-opacity',

--- a/src/components/page/Top/logic.ts
+++ b/src/components/page/Top/logic.ts
@@ -42,8 +42,15 @@ export const checkForUpdate = async (): Promise<boolean> => {
   return result.data
 }
 
-export const executeUpdate = async () => {
-  await commands.executeUpdate()
+export const downloadUpdate = async (setTaskId: (taskId: string) => void) => {
+  const result = await commands.downloadUpdate()
+
+  if (result.status === 'ok') {
+    setTaskId(result.data)
+    return
+  }
+
+  console.error(result.error)
 }
 
 export const dismissUpdate = async () => {

--- a/src/lib/bindings.ts
+++ b/src/lib/bindings.ts
@@ -193,9 +193,17 @@ async checkForUpdate() : Promise<Result<boolean, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async executeUpdate() : Promise<Result<boolean, string>> {
+async downloadUpdate() : Promise<Result<string, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("execute_update") };
+    return { status: "ok", data: await TAURI_INVOKE("download_update") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async installUpdate() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("install_update") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -428,11 +436,13 @@ async requestStartupDeepLinkExecution() : Promise<Result<null, string>> {
 export const events = __makeEvents__<{
 addAssetDeepLink: AddAssetDeepLink,
 progressEvent: ProgressEvent,
-taskStatusChanged: TaskStatusChanged
+taskStatusChanged: TaskStatusChanged,
+updateProgress: UpdateProgress
 }>({
 addAssetDeepLink: "add-asset-deep-link",
 progressEvent: "progress-event",
-taskStatusChanged: "task-status-changed"
+taskStatusChanged: "task-status-changed",
+updateProgress: "update-progress"
 })
 
 /** user-defined constants **/
@@ -471,6 +481,7 @@ export type TaskStatus = "Running" | "Completed" | "Cancelled" | "Failed"
 export type TaskStatusChanged = { id: string; status: TaskStatus }
 export type Theme = "light" | "dark" | "system"
 export type UpdateChannel = "Stable" | "PreRelease"
+export type UpdateProgress = { progress: number }
 export type WorldObject = { id: string; description: AssetDescription; category: string }
 
 /** tauri-specta globals **/


### PR DESCRIPTION
## Before
- アップデートを実行するとバックグラウンドでダウンロードが行われる
- ダウンロードの進行状況が表示されない
- ダウンロードが完了すると勝手に再起動される

## After
- ダウンロードがプログレスバーで表示される
- ダウンロード後にアップデートボタンを押して初めて再起動される

![image](https://github.com/user-attachments/assets/82125092-fbf0-44d1-b4a8-85343e86292c)

## Issues
- #290

resolve #290 
