### PR TITLE
セットアップページにおけるエラー文の翻訳欠けを修正

### DIFF
--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -296,7 +296,7 @@
     "setup:tab:2:title": "Select storage location",
     "setup:tab:2:description-1": "Choose a directory to store the asset data",
     "setup:tab:2:description-2": "This directory can be changed later in the settings tab",
-    "setup:tab:2:directory-open-error-toast": "Failed to open the directory",
+    "setup:tab:2:directory-open-error-toast": "Failed to open directory",
 
     "setup:tab:2:input-label": "Current storage location",
 

--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -284,7 +284,7 @@
     "top:update-dialog:downloading:posttext": "%)",
     "top:update-dialog:download-complete": "Update downloaded",
     "top:update-dialog:execute": "Update",
-  
+
     "top:add-text": "Drop files to add assets",
 
     "setup:welcome": "Welcome to KonoAsset!",
@@ -296,6 +296,7 @@
     "setup:tab:2:title": "Select storage location",
     "setup:tab:2:description-1": "Choose a directory to store the asset data",
     "setup:tab:2:description-2": "This directory can be changed later in the settings tab",
+    "setup:tab:2:directory-open-error-toast": "Failed to open the directory",
 
     "setup:tab:2:input-label": "Current storage location",
 

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -296,7 +296,7 @@
     "setup:tab:2:title": "Select storage location",
     "setup:tab:2:description-1": "Choose a directory to store the asset data",
     "setup:tab:2:description-2": "This directory can be changed later in the settings tab",
-    "setup:tab:2:directory-open-error-toast": "Failed to open the directory",
+    "setup:tab:2:directory-open-error-toast": "Failed to open directory",
 
     "setup:tab:2:input-label": "Current storage location",
 

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -296,6 +296,7 @@
     "setup:tab:2:title": "Select storage location",
     "setup:tab:2:description-1": "Choose a directory to store the asset data",
     "setup:tab:2:description-2": "This directory can be changed later in the settings tab",
+    "setup:tab:2:directory-open-error-toast": "Failed to open the directory",
 
     "setup:tab:2:input-label": "Current storage location",
 

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -296,6 +296,7 @@
     "setup:tab:2:title": "データの保存場所の選択",
     "setup:tab:2:description-1": "アセットのデータを保存するディレクトリを選択します",
     "setup:tab:2:description-2": "このディレクトリは後から設定で変更できます",
+    "setup:tab:2:directory-open-error-toast": "ディレクトリを開けませんでした",
 
     "setup:tab:2:input-label": "現在の保存場所",
 

--- a/src/components/page/Setup/tabs/DataPathSelector/index.tsx
+++ b/src/components/page/Setup/tabs/DataPathSelector/index.tsx
@@ -25,7 +25,7 @@ export const DataPathSelector: FC<Props> = ({ path, setPath }) => {
     }
 
     toast({
-      title: 'エラー: ディレクトリを開けませんでした',
+      title: t('setup:tab:2:directory-open-error-toast'),
       description: result.error,
     })
   }


### PR DESCRIPTION
## 概要
ディレクトリが開けなかった場合に表示するトーストのタイトルが、日本語でフロントエンドのファイルに直書きされている問題を修正

## Issues
- #293 

resolve #293 