### PR TITLE
エラーのトーストの「エラー:」を無しで統一

### DIFF
--- a/locales/en-GB.json
+++ b/locales/en-GB.json
@@ -40,7 +40,7 @@
 
     "addasset:success-toast": "Asset added successfully!",
     "addasset:cancel-toast": "Cancelled",
-    "addasset:error-toast": "Error: Failed to add asset",
+    "addasset:error-toast": "Failed to add asset",
     "addasset:error-toast:description": "Check the log for error details",
     "addasset:import-error-toast": "Failed to import data",
     "addasset:import-start-error-toast": "Failed to start data import",

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -40,7 +40,7 @@
 
     "addasset:success-toast": "Asset added successfully!",
     "addasset:cancel-toast": "Cancelled",
-    "addasset:error-toast": "Error: Failed to add asset",
+    "addasset:error-toast": "Failed to add asset",
     "addasset:error-toast:description": "Check the log for error details",
     "addasset:import-error-toast": "Failed to import data",
     "addasset:import-start-error-toast": "Failed to start data import",

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -40,7 +40,7 @@
 
     "addasset:success-toast": "アセットが追加されました！",
     "addasset:cancel-toast": "キャンセルされました",
-    "addasset:error-toast": "エラー: 追加に失敗しました",
+    "addasset:error-toast": "追加に失敗しました",
     "addasset:error-toast:description": "エラー内容はログを参照してください",
     "addasset:import-error-toast": "データのインポートに失敗しました",
     "addasset:import-start-error-toast": "データのインポートを開始できませんでした",


### PR DESCRIPTION
## 概要
エラー時に表示するトーストのタイトルが「エラー: 」で始まるものと、そうでないものが混在していたため、無しに統一

## Issues
- #295 

resolve #295 