### PR TITLE
設定ファイルのロードに失敗しているとエラー画面に文字が表示されない問題を修正

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,7 +8,7 @@ use deep_link::{
     execute_deep_links, parse_args_to_deep_links,
 };
 use definitions::entities::{InitialSetup, LoadResult, ProgressEvent};
-use language::load::load_from_language_code;
+use language::{load::load_from_language_code, structs::LanguageCode};
 use preference::store::PreferenceStore;
 use task::{cancellable_task::TaskContainer, definitions::TaskStatusChanged};
 use tauri::{async_runtime::Mutex, AppHandle, Manager};
@@ -100,6 +100,19 @@ pub fn run() {
 
             app.manage(arc_mutex(deep_links));
 
+            let default_language_data = load_from_language_code(LanguageCode::EnUs);
+            if let Err(e) = default_language_data {
+                log::error!("{}", e);
+                app.manage(LoadResult::error(false, e));
+
+                // Err を返すとアプリケーションが終了してしまうため Ok を返す
+                return Ok(());
+            }
+            let default_language_data = default_language_data.unwrap();
+            let lang_state = arc_mutex(default_language_data);
+
+            app.manage(lang_state.clone());
+
             let preference_file_path = app
                 .path()
                 .app_local_data_dir()
@@ -139,7 +152,7 @@ pub fn run() {
                 return Ok(());
             }
 
-            app.manage(arc_mutex(language_data.unwrap()));
+            *lang_state.blocking_lock() = language_data.unwrap();
 
             let result = load_store_provider(&data_dir);
             if let Err(err) = result {

--- a/src/components/context/LocalizationContext/hook.ts
+++ b/src/components/context/LocalizationContext/hook.ts
@@ -27,10 +27,6 @@ export const useLocalizationContext = (): LocalizationContextType => {
 
   useEffect(() => {
     setLanguage(preference.language)
-  }, [])
-
-  useEffect(() => {
-    setLanguage(preference.language)
   }, [preference.language])
 
   const loadLanguageFile = async (file: string) => {

--- a/src/components/context/LocalizationContext/index.tsx
+++ b/src/components/context/LocalizationContext/index.tsx
@@ -9,7 +9,7 @@ export type LocalizationContextType = {
 
 export const LocalizationContext = createContext<LocalizationContextType>({
   data: {
-    language: 'ja-JP',
+    language: 'en-US',
     data: {},
   },
   loadLanguageFile: async () => {},

--- a/src/components/page/LoadError/hook.ts
+++ b/src/components/page/LoadError/hook.ts
@@ -1,12 +1,17 @@
-import { commands } from '@/lib/bindings'
+import { PreferenceContext } from '@/components/context/PreferenceContext'
+import { commands, LanguageCode } from '@/lib/bindings'
+import { useContext } from 'react'
 
 type ReturnProps = {
   openAppDir: () => void
   openAssetDir: () => void
   openMetadataDir: () => void
+  onLanguageChanged: (value: LanguageCode) => Promise<void>
 }
 
 export const useLoadErrorPage = (): ReturnProps => {
+  const { preference, setPreference } = useContext(PreferenceContext)
+
   const openAppDir = async () => {
     await commands.openAppDir()
   }
@@ -19,5 +24,14 @@ export const useLoadErrorPage = (): ReturnProps => {
     await commands.openMetadataDir()
   }
 
-  return { openAppDir, openAssetDir, openMetadataDir }
+  const onLanguageChanged = async (value: LanguageCode) => {
+    setPreference({ ...preference, language: value }, false)
+  }
+
+  return {
+    openAppDir,
+    openAssetDir,
+    openMetadataDir,
+    onLanguageChanged,
+  }
 }

--- a/src/components/page/LoadError/index.tsx
+++ b/src/components/page/LoadError/index.tsx
@@ -16,7 +16,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu'
-import { FileWarning, Folder } from 'lucide-react'
+import { FileWarning, Folder, Languages } from 'lucide-react'
 import { FC } from 'react'
 import { cn } from '@/lib/utils'
 import {
@@ -35,13 +35,34 @@ type Props = {
 }
 
 const LoadErrorPage: FC<Props> = ({ preferenceLoaded, error }) => {
-  const { openAppDir, openAssetDir, openMetadataDir } = useLoadErrorPage()
+  const { openAppDir, openAssetDir, openMetadataDir, onLanguageChanged } =
+    useLoadErrorPage()
 
   const { t } = useLocalization()
 
   return (
     <div className="h-screen w-screen flex flex-col items-center justify-center">
-      <Card className="w-[600px] p-6">
+      <Card className="w-[600px] p-6 relative">
+        <div className="absolute top-5 right-5">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="secondary" size="icon">
+                <Languages />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem onClick={() => onLanguageChanged('ja-JP')}>
+                日本語
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onLanguageChanged('en-US')}>
+                English (US)
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onLanguageChanged('en-GB')}>
+                English (UK)
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
         <CardHeader>
           <CardTitle className="flex flex-row items-center justify-center">
             <FileWarning className="text-primary mr-2" size={30} />


### PR DESCRIPTION
## 概要
使用する言語は設定ファイルによって決定されているが、`preference.json` の読み込みに失敗している場合言語データが読み込まれず、エラー画面に文字が表示されない問題が発生していた

この問題を修正するため、`preference.json` が読み込めなかった場合は `en-US` をデフォルト値として言語データを読み込み、エラー画面上で表示言語を変更できる機能を実装した

## Issues
#298 

resolve #298 