### PR TITLE
metadata を `dev.konoasset.app` ディレクトリに作成するように

### DIFF
--- a/src-tauri/src/adapter/exporter/avatar_explorer/logic.rs
+++ b/src-tauri/src/adapter/exporter/avatar_explorer/logic.rs
@@ -440,7 +440,7 @@ mod tests {
         .unwrap();
 
         let mut provider = StoreProvider::create(store_path).unwrap();
-        provider.load_all_assets_from_files(false).await.unwrap();
+        provider.load_all_assets_from_files().await.unwrap();
         let provider = Arc::new(Mutex::new(provider));
 
         export_as_avatar_explorer_compatible_structure(provider, &exported_path, None)

--- a/src-tauri/src/adapter/exporter/human_readable_zip_exporter.rs
+++ b/src-tauri/src/adapter/exporter/human_readable_zip_exporter.rs
@@ -275,7 +275,7 @@ mod tests {
         .unwrap();
 
         let mut provider = StoreProvider::create(&provider).unwrap();
-        provider.load_all_assets_from_files(false).await.unwrap();
+        provider.load_all_assets_from_files().await.unwrap();
 
         let provider = Arc::new(Mutex::new(provider));
 

--- a/src-tauri/src/adapter/exporter/konoasset_exporter.rs
+++ b/src-tauri/src/adapter/exporter/konoasset_exporter.rs
@@ -160,10 +160,7 @@ mod tests {
         .unwrap();
 
         let mut store_provider = StoreProvider::create(&provider).unwrap();
-        store_provider
-            .load_all_assets_from_files(false)
-            .await
-            .unwrap();
+        store_provider.load_all_assets_from_files().await.unwrap();
 
         let store_provider = Arc::new(Mutex::new(store_provider));
 

--- a/src-tauri/src/adapter/exporter/util.rs
+++ b/src-tauri/src/adapter/exporter/util.rs
@@ -99,7 +99,7 @@ mod tests {
         .unwrap();
 
         let mut provider = StoreProvider::create(provider).unwrap();
-        provider.load_all_assets_from_files(false).await.unwrap();
+        provider.load_all_assets_from_files().await.unwrap();
 
         let provider = Arc::new(Mutex::new(provider));
 

--- a/src-tauri/src/adapter/importer/directory.rs
+++ b/src-tauri/src/adapter/importer/directory.rs
@@ -159,7 +159,7 @@ where
     }
 
     let mut provider = StoreProvider::create(&path.to_path_buf())?;
-    provider.load_all_assets_from_files(false).await?;
+    provider.load_all_assets_from_files().await?;
 
     Ok(provider)
 }
@@ -241,7 +241,7 @@ mod tests {
         .unwrap();
 
         let mut provider = StoreProvider::create(dest).unwrap();
-        provider.load_all_assets_from_files(false).await.unwrap();
+        provider.load_all_assets_from_files().await.unwrap();
 
         assert_eq!(provider.get_avatar_store().get_all().await.len(), 1);
         assert_eq!(

--- a/src-tauri/src/adapter/importer/zip.rs
+++ b/src-tauri/src/adapter/importer/zip.rs
@@ -123,7 +123,7 @@ mod tests {
         .unwrap();
 
         let mut provider = StoreProvider::create(dest).unwrap();
-        provider.load_all_assets_from_files(false).await.unwrap();
+        provider.load_all_assets_from_files().await.unwrap();
 
         assert_eq!(provider.get_avatar_store().get_all().await.len(), 1);
         assert_eq!(

--- a/src-tauri/src/data_store/provider.rs
+++ b/src-tauri/src/data_store/provider.rs
@@ -48,12 +48,7 @@ impl StoreProvider {
         })
     }
 
-    pub async fn load_all_assets_from_files(&mut self, backup: bool) -> Result<(), String> {
-        if backup {
-            backup_metadata(&self.data_dir).await?;
-            prune_old_backup(&self.data_dir).await?;
-        }
-
+    pub async fn load_all_assets_from_files(&mut self) -> Result<(), String> {
         match self.avatar_store.load().await {
             Ok(_) => {}
             Err(e) => return Err(e),
@@ -324,7 +319,7 @@ impl StoreProvider {
 
         self.data_dir = new_path;
 
-        self.load_all_assets_from_files(true).await
+        self.load_all_assets_from_files().await
     }
 
     pub async fn remove_all_dependencies(&self, id: Uuid) -> Result<(), String> {
@@ -333,6 +328,59 @@ impl StoreProvider {
         self.world_object_store.delete_dependency(id).await?;
 
         return Ok(());
+    }
+
+    pub async fn create_backup<P: AsRef<Path>>(
+        &self,
+        metadata_backup_dir: P,
+    ) -> Result<(), String> {
+        prune_old_backup(&metadata_backup_dir).await?;
+
+        let metadata_path = self.data_dir.join("metadata");
+        if !metadata_path.exists() {
+            return Ok(());
+        }
+
+        let dir_name = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
+        let backup_path = metadata_backup_dir.as_ref().join(dir_name);
+
+        let result = std::fs::create_dir_all(&backup_path);
+
+        if result.is_err() {
+            return Err("Failed to create backup directory".into());
+        }
+
+        let files = vec![
+            Avatar::filename(),
+            AvatarWearable::filename(),
+            WorldObject::filename(),
+        ];
+
+        for file in files {
+            let path = metadata_path.join(&file);
+            if !path.exists() {
+                continue;
+            }
+
+            let backup_file = backup_path.join(&file);
+
+            let result =
+                modify_guard::copy_file(&path, &backup_file, false, FileTransferGuard::none())
+                    .await;
+
+            if let Err(e) = result {
+                let msg = format!("Failed to backup metadata: {:?}", e);
+                log::warn!("{}", msg);
+                return Err(msg);
+            }
+        }
+
+        log::info!(
+            "Successfully created metadata backup in {}",
+            backup_path.display()
+        );
+
+        Ok(())
     }
 }
 
@@ -371,56 +419,8 @@ async fn rename_conflict_dir<P: AsRef<Path>>(path: P) -> Result<(), std::io::Err
     .await
 }
 
-async fn backup_metadata(data_dir: &PathBuf) -> Result<(), String> {
-    let metadata_path = data_dir.join("metadata");
-    let backup_path = metadata_path.join("backups");
-
-    if !metadata_path.exists() {
-        return Ok(());
-    }
-
-    let dir_name = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
-    let backup_path = backup_path.join(dir_name);
-
-    let result = std::fs::create_dir_all(&backup_path);
-
-    if result.is_err() {
-        return Err("Failed to create backup directory".into());
-    }
-
-    let files = vec![
-        Avatar::filename(),
-        AvatarWearable::filename(),
-        WorldObject::filename(),
-    ];
-
-    for file in files {
-        let path = metadata_path.join(&file);
-        if !path.exists() {
-            continue;
-        }
-
-        let backup_file = backup_path.join(&file);
-
-        let result =
-            modify_guard::copy_file(&path, &backup_file, false, FileTransferGuard::none()).await;
-
-        if let Err(e) = result {
-            let msg = format!("Failed to backup metadata: {:?}", e);
-            log::warn!("{}", msg);
-            return Err(msg);
-        }
-    }
-
-    log::info!(
-        "Successfully created metadata backup in {}",
-        backup_path.display()
-    );
-
-    Ok(())
-}
-
-async fn prune_old_backup(data_dir: &PathBuf) -> Result<(), String> {
+async fn prune_old_backup<P: AsRef<Path>>(data_dir: P) -> Result<(), String> {
+    let data_dir = data_dir.as_ref();
     let backup_path = data_dir.join("metadata/backups");
 
     if !backup_path.exists() {
@@ -515,7 +515,7 @@ mod tests {
 
         let mut provider = StoreProvider::create(&target_one).unwrap();
 
-        provider.load_all_assets_from_files(false).await.unwrap();
+        provider.load_all_assets_from_files().await.unwrap();
 
         let ids = provider.get_used_ids().await;
 
@@ -526,7 +526,7 @@ mod tests {
 
         let mut external_provider = StoreProvider::create(&target_two).unwrap();
         external_provider
-            .load_all_assets_from_files(false)
+            .load_all_assets_from_files()
             .await
             .unwrap();
 
@@ -567,7 +567,7 @@ mod tests {
 
         let mut provider = StoreProvider::create(&current_path).unwrap();
 
-        provider.load_all_assets_from_files(false).await.unwrap();
+        provider.load_all_assets_from_files().await.unwrap();
 
         let result = provider
             .internal_migrate_data_dir(None, new_path)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -216,7 +216,7 @@ fn load_store_provider(
     let mut store_provider = result.unwrap();
     let store_provider_ref = &mut store_provider;
 
-    let metadata_backup_dir = app_local_dir.join("backup").join("metadata");
+    let metadata_backup_dir = app_local_dir.join("backups").join("metadata");
 
     let result = tauri::async_runtime::block_on(async move {
         if let Err(e) = migrate_legacy_backup_dir(store_provider_ref, &metadata_backup_dir).await {


### PR DESCRIPTION
## 概要
これまではデータディレクトリの `metadata/backups` に作成していたバックアップを、`%appdata%/../Local/dev.konoasset.app/backups/metadata` に作成するようにすることで、誤削除を減らす

まだ旧バックアップを新パスの方に移動させる処理を書いていないので Draft

## Issues
- #368 

resolved #368 