### PR TITLE
MultiSelectコンポーネントのバッジがXボタンに被る問題を修正

### DIFF
--- a/src/components/model/MainSidebar/components/MultiFilterItemSelector/index.tsx
+++ b/src/components/model/MainSidebar/components/MultiFilterItemSelector/index.tsx
@@ -49,6 +49,7 @@ const MultiFilterItemSelector = ({
       </div>
       <MultipleSelector
         className="mt-2"
+        badgeClassName="max-w-42"
         options={candidates}
         value={value}
         onChange={onValueChange}

--- a/src/components/model/asset-dialogs/components/tabs/ManualInputTab/layout/AvatarLayout/index.tsx
+++ b/src/components/model/asset-dialogs/components/tabs/ManualInputTab/layout/AvatarLayout/index.tsx
@@ -47,6 +47,7 @@ const AvatarLayout = ({ form }: Props) => {
           options={tagCandidates}
           placeholder={t('addasset:tag:placeholder')}
           className="max-w-[600px]"
+          badgeClassName="max-w-[540px]"
           hidePlaceholderWhenSelected
           creatable
           emptyIndicator={

--- a/src/components/model/asset-dialogs/components/tabs/ManualInputTab/layout/AvatarWearableLayout/index.tsx
+++ b/src/components/model/asset-dialogs/components/tabs/ManualInputTab/layout/AvatarWearableLayout/index.tsx
@@ -94,6 +94,7 @@ const AvatarWearableLayout = ({ form }: Props) => {
             options={supportedAvatarCandidates}
             placeholder={t('addasset:supported-avatars:placeholder')}
             className="max-w-72"
+            badgeClassName="max-w-58"
             hidePlaceholderWhenSelected
             creatable
             emptyIndicator={
@@ -151,6 +152,7 @@ const AvatarWearableLayout = ({ form }: Props) => {
           options={tagCandidates}
           placeholder={t('addasset:tag:placeholder')}
           className="max-w-72"
+          badgeClassName="max-w-58"
           hidePlaceholderWhenSelected
           creatable
           emptyIndicator={

--- a/src/components/model/asset-dialogs/components/tabs/ManualInputTab/layout/WorldObjectLayout/index.tsx
+++ b/src/components/model/asset-dialogs/components/tabs/ManualInputTab/layout/WorldObjectLayout/index.tsx
@@ -95,6 +95,7 @@ const WorldObjectLayout = ({ form }: Props) => {
           options={tagCandidates}
           placeholder={t('addasset:tag:placeholder')}
           className="max-w-72"
+          badgeClassName="max-w-58"
           hidePlaceholderWhenSelected
           creatable
           emptyIndicator={

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -266,8 +266,7 @@ const MultipleSelector = ({
       return
     }
 
-    // Use setTimeout to ensure DOM is updated
-    const timer = setTimeout(() => {
+    const animationFrameId = requestAnimationFrame(() => {
       if (!badgesContainerRef.current) return
 
       // Get all badge elements
@@ -292,9 +291,9 @@ const MultipleSelector = ({
       }
 
       setLastBadgeInFirstRow(lastIndex)
-    }, 0)
+    })
 
-    return () => clearTimeout(timer)
+    return () => cancelAnimationFrame(animationFrameId)
   }, [selected])
 
   useEffect(() => {

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -260,7 +260,7 @@ const MultipleSelector = ({
   }
 
   // Check badge positions to find the last badge in the first row
-  useEffect(() => {
+  React.useLayoutEffect(() => {
     if (selected.length <= 1) {
       setLastBadgeInFirstRow(null)
       return

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -224,9 +224,13 @@ const MultipleSelector = ({
   const debouncedSearchTerm = useDebounce(inputValue, delay || 500)
 
   const inputDivRef = React.useRef<HTMLDivElement>(null)
+  const badgesContainerRef = React.useRef<HTMLDivElement>(null)
   const [commandListMaxHeight, setCommandListMaxHeight] =
     React.useState<number>(300)
   const [inputHeight, setInputHeight] = React.useState<number>(0)
+  const [lastBadgeInFirstRow, setLastBadgeInFirstRow] = React.useState<
+    number | null
+  >(null)
   const { getElementProperty } = useGetElementProperty(inputDivRef)
 
   // suggestの向きと高さを適切に設定する
@@ -254,6 +258,44 @@ const MultipleSelector = ({
 
     setCommandListMaxHeight(commandListHeight)
   }
+
+  // Check badge positions to find the last badge in the first row
+  useEffect(() => {
+    if (selected.length <= 1) {
+      setLastBadgeInFirstRow(null)
+      return
+    }
+
+    // Use setTimeout to ensure DOM is updated
+    const timer = setTimeout(() => {
+      if (!badgesContainerRef.current) return
+
+      // Get all badge elements
+      const badges = Array.from(
+        badgesContainerRef.current.querySelectorAll('[data-badge]'),
+      ) as HTMLElement[]
+
+      if (badges.length === 0) return
+
+      // Get the top position of the first badge
+      const firstRowTop = badges[0].getBoundingClientRect().top
+      let lastIndex = 0
+
+      // Find the last badge in the first row
+      for (let i = 1; i < badges.length; i++) {
+        const top = badges[i].getBoundingClientRect().top
+        if (top > firstRowTop + 5) {
+          // 5px threshold for detecting new row
+          break
+        }
+        lastIndex = i
+      }
+
+      setLastBadgeInFirstRow(lastIndex)
+    }, 0)
+
+    return () => clearTimeout(timer)
+  }, [selected])
 
   useEffect(() => {
     updateCommandListDirectionAndMaxHeight()
@@ -544,17 +586,27 @@ const MultipleSelector = ({
       >
         <div className="relative flex flex-wrap gap-1">
           <ScrollArea className="max-h-36">
-            <div className="flex flex-wrap gap-1 py-2">
-              {selected.map((option) => {
+            <div
+              className="flex flex-wrap gap-1 py-2 pr-2"
+              ref={badgesContainerRef}
+            >
+              {selected.map((option, index) => {
                 return (
                   <Badge
                     key={option.value}
                     className={cn(
-                      'cursor-default',
+                      'cursor-default flex shrink',
                       'data-disabled:bg-muted-foreground data-disabled:text-muted data-disabled:hover:bg-muted-foreground overflow-hidden',
                       'data-fixed:bg-muted-foreground data-fixed:text-muted data-fixed:hover:bg-muted-foreground overflow-hidden',
+                      // Xボタンと重ならないようにする
+                      {
+                        'mr-6':
+                          selected.length === 1 ||
+                          lastBadgeInFirstRow === index,
+                      },
                       badgeClassName,
                     )}
+                    data-badge={true}
                     data-fixed={option.fixed}
                     data-disabled={disabled || undefined}
                   >


### PR DESCRIPTION
## 概要
MultipleSelector コンポーネントにおいて、全て削除する X ボタンに選択中のバッジが被ってしまい、バッジの X ボタンが押せなくなってしまう問題を修正しました

また、非常にテキストが長いアイテムを入れた時に表示が崩れる問題を修正しました

## スクリーンショット

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/4ecfbcd4-1613-45bd-9cf5-31260b04101e) | ![image](https://github.com/user-attachments/assets/1c845762-d707-47b3-b2e7-691b73b679cc) | 