### PR TITLE
TextInputSelect のサジェストをエンターキーで確定できない問題を修正しました

### DIFF
--- a/src/components/ui/text-input-select.tsx
+++ b/src/components/ui/text-input-select.tsx
@@ -265,9 +265,12 @@ const TextInputSelect = forwardRef<TextInputSelectRef, TextInputSelectProps>(
       (option: Option) => {
         const newValue = option.value.trim()
         setInputValue(newValue)
-        onChange?.(newValue)
-        setOpen(false)
-        inputRef.current?.blur()
+        // Ensure the input value is updated before calling onChange
+        requestAnimationFrame(() => {
+          onChange?.(newValue)
+          setOpen(false)
+          inputRef.current?.blur()
+        })
       },
       [onChange],
     )


### PR DESCRIPTION
## 概要
TextInputSelect のサジェストをエンターキーで確定できない問題を修正しました

## Issues
- #421 

resolved #421 